### PR TITLE
Replaced a Perl 5.10-ism with equivalent Perl 5.8 code.

### DIFF
--- a/lib/Dancer2/Template/Xslate.pm
+++ b/lib/Dancer2/Template/Xslate.pm
@@ -32,7 +32,7 @@ sub _build_engine {
     # Dancer2 inject a couple options without asking; Text::Xslate protests:
     delete $config{environment};
     if ( my $location = delete $config{location} ) {
-		unless (exists $config{path} and defined $config{path}) {
+		unless (defined $config{path}) {
 			$config{path} = [$location];
 		}
     }

--- a/lib/Dancer2/Template/Xslate.pm
+++ b/lib/Dancer2/Template/Xslate.pm
@@ -1,6 +1,6 @@
 package Dancer2::Template::Xslate;
 
-use v5.10;
+use v5.8;
 use strict;
 use warnings FATAL => 'all';
 use utf8;
@@ -32,7 +32,9 @@ sub _build_engine {
     # Dancer2 inject a couple options without asking; Text::Xslate protests:
     delete $config{environment};
     if ( my $location = delete $config{location} ) {
-        $config{path} //= [$location];
+		unless (exists $config{path} and defined $config{path}) {
+			$config{path} = [$location];
+		}
     }
 
     return Text::Xslate->new(%config);


### PR DESCRIPTION
The current version of Dancer2::Template::Xslate requires Perl 5.10, but changing this one line allows it to run on Perl 5.8, which extends support back about 5 years, greatly expanding the number of machines that can run the plugin.